### PR TITLE
Vince/locking

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -43,6 +43,10 @@ def handler(event, context):
                     logger.error('Aborting executing: {}'.format(msg))
         retval = step_fn_resps
 
+    # Increment Count
+    elif action == 'increment-count':
+        retval = int(event['iteration_count']) + 1
+
     # Test New ASG Instance
     elif action == 'ondemand-instance-healthy':
         retval = stepfns.asg_instance_state(event['autoscaling_group'], event['ondemand_instance_id'])

--- a/handler.py
+++ b/handler.py
@@ -56,29 +56,17 @@ def handler(event, context):
     elif action == 'check-spot':
         retval = stepfns.get_spot_request_status(event['spot_request']['SpotInstanceRequestId'])
 
-    # Check ASG and Tag Spot
-    elif action == 'check-asg-and-tag-spot':
-        retval = stepfns.check_asg_and_tag_spot(event['autoscaling_group'], event['spot_request_result'], event['ondemand_instance_id'])
-
     # AutoScaling Group Disappeared
     elif action == 'term-spot-instance':
         retval = stepfns.terminate_ec2_instance(event.get('spot_request_result'))
 
-    # Term OnDemand Before Attach Spot
-    elif action == 'term-ondemand-attach-spot':
-        retval = stepfns.attach_spot_instance(event['autoscaling_group'], event['spot_request_result'], event['ondemand_instance_id'])
-
-    # Attach Spot Before Term OnDemand
+    # Attach Spot Instance
     elif action == 'attach-spot':
-        retval = stepfns.attach_spot_instance(event['autoscaling_group'], event['spot_request_result'], None)
+        retval = stepfns.attach_spot_instance(event['autoscaling_group'], event['spot_request_result'], event['ondemand_instance_id'])
 
     # Test Attached Instance
     elif action == 'spot-instance-healthy':
         retval = stepfns.asg_instance_state(event['autoscaling_group'], event['spot_request_result'])
-
-    # Terminate OD Instance
-    elif action == 'term-ondemand-instance':
-        retval = stepfns.terminate_asg_instance(event['ondemand_instance_id'])
 
     else:
         raise Exception('SPOPTIMIZE_ACTION env var specifies unknown action: {}'.format(action))

--- a/handler.py
+++ b/handler.py
@@ -53,8 +53,9 @@ def handler(event, context):
 
     # Request Spot Instance
     elif action == 'request-spot':
+        client_token = '{0}-{1}'.format(event['ondemand_instance_id'], event['iteration_count'])
         retval = stepfns.request_spot_instance(event['autoscaling_group'], event['launch_az'],
-                                               event['launch_subnet_id'], event['ondemand_instance_id'])
+                                               event['launch_subnet_id'], client_token)
 
     # Check Spot Request
     elif action == 'check-spot':

--- a/handler.py
+++ b/handler.py
@@ -65,6 +65,14 @@ def handler(event, context):
     elif action == 'term-spot-instance':
         retval = stepfns.terminate_ec2_instance(event.get('spot_request_result'))
 
+    # Acquire AutoScaling Group Lock
+    elif action == 'acquire-lock':
+        retval = True
+
+    # Release AutoScaling Group Lock
+    elif action == 'release-lock':
+        retval = True
+
     # Attach Spot Instance
     elif action == 'attach-spot':
         retval = stepfns.attach_spot_instance(event['autoscaling_group'], event['spot_request_result'], event['ondemand_instance_id'])

--- a/iam-global.yml
+++ b/iam-global.yml
@@ -68,13 +68,18 @@ Resources:
             - ec2:DescribeInstances
             - ec2:DescribeTags
             - ec2:RequestSpotInstances
+            - ec2:TerminateInstances
           Resource: "*"
-        - Sid: StepFns
+        - Sid: StepFnStart
+          Effect: Allow
+          Action:
+            - states:StartExecution
+          Resource: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StackBasename}-*"
+        - Sid: StepFnDescribeExec
           Effect: Allow
           Action:
             - states:DescribeExecution
-            - states:StartExecution
-          Resource: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StackBasename}-*"
+          Resource: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:execution:${StackBasename}-*"
         - Sid: DynamoDbLockTable
           Effect: Allow
           Action:

--- a/iam-global.yml
+++ b/iam-global.yml
@@ -2,6 +2,10 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: IAM Resources for Spoptimize
 
 Parameters:
+  StackBasename:
+    Description: Base name of Spoptimize stacks
+    Type: String
+    Default: spoptimize
   RolePath:
     Description: Path to pass to IAM resources
     Type: String
@@ -20,7 +24,7 @@ Resources:
           - Sid: InvokeLambda
             Effect: Allow
             Action: lambda:InvokeFunction
-            Resource: !Sub "arn:aws:lambda:*:${AWS::AccountId}:function:spoptimize*"
+            Resource: !Sub "arn:aws:lambda:*:${AWS::AccountId}:function:${StackBasename}*"
 
   StateMachineRole:
     Type: AWS::IAM::Role
@@ -70,7 +74,14 @@ Resources:
           Action:
             - states:DescribeExecution
             - states:StartExecution
-          Resource: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:spoptimize-*"
+          Resource: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${StackBasename}-*"
+        - Sid: DynamoDbLockTable
+          Effect: Allow
+          Action:
+            - dynamodb:DeleteItem
+            - dynamodb:GetItem
+            - dynamodb:PutItem
+          Resource: !Sub "arn:aws:dynamodb:*:${AWS::AccountId}:table/${StackBasename}-autoscaling-group-locks"
         - Sid: PassEc2IamRole
           Effect: Allow
           Action: iam:PassRole

--- a/sam.yml
+++ b/sam.yml
@@ -32,6 +32,23 @@ Globals:
         SPOPTIMIZE_DEBUG: !Ref DebugLambdas
 
 Resources:
+  LockTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub "${AWS::StackName}-autoscaling-group-locks"
+      AttributeDefinitions:
+        - AttributeName: group_name
+          AttributeType: S
+      KeySchema:
+        - AttributeName: group_name
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+
   StartStateMachineFn:
     Type: AWS::Serverless::Function
     Properties:
@@ -114,6 +131,8 @@ Resources:
       Environment:
         Variables:
           SPOPTIMIZE_ACTION: 'acquire-lock'
+          SPOPTIMIZE_LOCK_TABLE: !Ref LockTable
+          SPOPTIMIZE_SFN_ARN: !Ref SpotRequestor
 
   ReleaseAutoScalingGroupLock:
     Type: AWS::Serverless::Function
@@ -125,6 +144,8 @@ Resources:
       Environment:
         Variables:
           SPOPTIMIZE_ACTION: 'release-lock'
+          SPOPTIMIZE_LOCK_TABLE: !Ref LockTable
+          SPOPTIMIZE_SFN_ARN: !Ref SpotRequestor
 
   AttachSpot:
     Type: AWS::Serverless::Function
@@ -301,7 +322,7 @@ Resources:
                 "Retry": [{
                   "ErrorEquals": [ "GroupLocked" ],
                   "IntervalSeconds": 5,
-                  "MaxAttempts": 7,
+                  "MaxAttempts": 20,
                   "BackoffRate": 1.5
                 },{
                   "ErrorEquals": [ "States.ALL" ],

--- a/sam.yml
+++ b/sam.yml
@@ -139,9 +139,9 @@ Resources:
                 "ResultPath": "$.ondemand_instance_status",
                 "Retry": [{
                   "ErrorEquals": [ "States.ALL" ],
-                  "IntervalSeconds": 10,
+                  "IntervalSeconds": 5,
                   "MaxAttempts": 5,
-                  "BackoffRate": 15
+                  "BackoffRate": 2.5
                 }]
               },
               "OD Instance Healthy?": {
@@ -172,9 +172,9 @@ Resources:
                 "Next": "Wait For Spot Request",
                 "Retry": [{
                   "ErrorEquals": [ "States.ALL" ],
-                  "IntervalSeconds": 10,
+                  "IntervalSeconds": 5,
                   "MaxAttempts": 5,
-                  "BackoffRate": 15
+                  "BackoffRate": 2.5
                 }]
               },
               "Wait For Spot Request": {
@@ -189,9 +189,9 @@ Resources:
                 "ResultPath": "$.spot_request_result",
                 "Retry": [{
                   "ErrorEquals": [ "States.ALL" ],
-                  "IntervalSeconds": 10,
+                  "IntervalSeconds": 5,
                   "MaxAttempts": 5,
-                  "BackoffRate": 15
+                  "BackoffRate": 2.5
                 }]
               },
               "Spot Request Status?": {
@@ -213,9 +213,9 @@ Resources:
                 "End": true,
                 "Retry": [{
                   "ErrorEquals": [ "States.ALL" ],
-                  "IntervalSeconds": 10,
+                  "IntervalSeconds": 5,
                   "MaxAttempts": 5,
-                  "BackoffRate": 15
+                  "BackoffRate": 2.5
                 }]
               },
               "Attach Spot Instance": {
@@ -225,9 +225,9 @@ Resources:
                 "Next": "Check Attachment?",
                 "Retry": [{
                   "ErrorEquals": [ "States.ALL" ],
-                  "IntervalSeconds": 10,
+                  "IntervalSeconds": 5,
                   "MaxAttempts": 5,
-                  "BackoffRate": 15
+                  "BackoffRate": 2.5
                 }]
               },
               "Check Attachment?": {
@@ -271,9 +271,9 @@ Resources:
                 "ResultPath": "$.spot_instance_status",
                 "Retry": [{
                   "ErrorEquals": [ "States.ALL" ],
-                  "IntervalSeconds": 10,
+                  "IntervalSeconds": 5,
                   "MaxAttempts": 5,
-                  "BackoffRate": 15
+                  "BackoffRate": 2.5
                 }]
               },
               "Spot Instance Healthy?": {

--- a/sam.yml
+++ b/sam.yml
@@ -104,7 +104,29 @@ Resources:
         Variables:
           SPOPTIMIZE_ACTION: 'term-spot-instance'
 
-  AttachSpotBeforeTermOnDemandFn:
+  AcquireAutoScalingGroupLock:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-acquire-lock"
+      Description: Acquires lock for autoscaling group
+      Role: !Sub "arn:aws:iam::${AWS::AccountId}:role/${StackBasename}-iam-global-lambda-role"
+      CodeUri: ./target/lambda-pkg.zip
+      Environment:
+        Variables:
+          SPOPTIMIZE_ACTION: 'acquire-lock'
+
+  ReleaseAutoScalingGroupLock:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-release-lock"
+      Description: Releases lock for autoscaling group
+      Role: !Sub "arn:aws:iam::${AWS::AccountId}:role/${StackBasename}-iam-global-lambda-role"
+      CodeUri: ./target/lambda-pkg.zip
+      Environment:
+        Variables:
+          SPOPTIMIZE_ACTION: 'release-lock'
+
+  AttachSpot:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub "${AWS::StackName}-attach-spot"
@@ -218,7 +240,7 @@ Resources:
                   "StringEquals": "Failure",
                   "Next": "Increment Failure Count"
                 }],
-                "Default": "Attach Spot Instance"
+                "Default": "Acquire AutoScaling Group Lock"
               },
               "Increment Failure Count": {
                 "Type": "Task",
@@ -248,11 +270,40 @@ Resources:
                 "SecondsPath": "$.spot_failure_sleep_interval",
                 "Next": "Test New ASG Instance"
               },
+              "Release Lock Before Spot Term": {
+                "Type": "Task",
+                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${StackBasename}-release-lock",
+                "ResultPath": "$.asg_lock",
+                "Next": "Terminate Spot",
+                "Retry": [{
+                  "ErrorEquals": [ "States.ALL" ],
+                  "IntervalSeconds": 5,
+                  "MaxAttempts": 5,
+                  "BackoffRate": 2.5
+                }]
+              },
               "Terminate Spot": {
                 "Type": "Task",
                 "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${StackBasename}-term-spot-instance",
                 "End": true,
                 "Retry": [{
+                  "ErrorEquals": [ "States.ALL" ],
+                  "IntervalSeconds": 5,
+                  "MaxAttempts": 5,
+                  "BackoffRate": 2.5
+                }]
+              },
+              "Acquire AutoScaling Group Lock": {
+                "Type": "Task",
+                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${StackBasename}-acquire-lock",
+                "ResultPath": "$.asg_lock",
+                "Next": "Attach Spot Instance",
+                "Retry": [{
+                  "ErrorEquals": [ "GroupLocked" ],
+                  "IntervalSeconds": 5,
+                  "MaxAttempts": 7,
+                  "BackoffRate": 1.5
+                },{
                   "ErrorEquals": [ "States.ALL" ],
                   "IntervalSeconds": 5,
                   "MaxAttempts": 5,
@@ -276,29 +327,41 @@ Resources:
                 "Choices": [{
                   "Variable": "$.spot_attach_result",
                   "StringEquals": "AutoScaling Group Disappeared",
-                  "Next": "Terminate Spot"
-                },{
-                  "Variable": "$.spot_attach_result",
-                  "StringEquals": "Spot Instance Disappeared",
-                  "Next": "Increment Failure Count"
+                  "Next": "Release Lock Before Spot Term"
                 },{
                   "Variable": "$.spot_attach_result",
                   "StringEquals": "OD Instance Disappeared Or Protected",
-                  "Next": "Terminate Spot"
+                  "Next": "Release Lock Before Spot Term"
                 },{
                   "Variable": "$.spot_attach_result",
                   "StringEquals": "AutoScaling group not sized correctly",
-                  "Next": "Terminate Spot"
+                  "Next": "Release Lock Before Spot Term"
+                },{
+                  "Variable": "$.spot_attach_result",
+                  "StringEquals": "Spot Instance Disappeared",
+                  "Next": "Release Lock Before Increment"
                 },{
                   "Variable": "$.spot_attach_result",
                   "StringEquals": "Instance missing",
-                  "Next": "Increment Failure Count"
+                  "Next": "Release Lock Before Increment"
                 },{
                   "Variable": "$.spot_attach_result",
                   "StringEquals": "Invalid instance",
-                  "Next": "Increment Failure Count"
+                  "Next": "Release Lock Before Increment"
                 }],
                 "Default": "Wait for Attachment"
+              },
+              "Release Lock Before Increment": {
+                "Type": "Task",
+                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${StackBasename}-release-lock",
+                "ResultPath": "$.asg_lock",
+                "Next": "Increment Failure Count",
+                "Retry": [{
+                  "ErrorEquals": [ "States.ALL" ],
+                  "IntervalSeconds": 5,
+                  "MaxAttempts": 5,
+                  "BackoffRate": 2.5
+                }]
               },
               "Wait for Attachment": {
                 "Type": "Wait",
@@ -322,23 +385,44 @@ Resources:
                 "Choices": [{
                   "Variable": "$.spot_instance_status",
                   "StringEquals": "Healthy",
-                  "Next": "Success"
+                  "Next": "Release Lock after Success"
                 },{
                   "Variable": "$.spot_instance_status",
                   "StringEquals": "Terminated",
-                  "Next": "Spot Instance Failure"
+                  "Next": "Release Lock After Spot Failure"
                 },{
                   "Variable": "$.spot_instance_status",
                   "StringEquals": "AutoScaling Group Disappeared",
-                  "Next": "Terminate Spot"
+                  "Next": "Release Lock Before Spot Term"
                 }],
                 "Default": "Wait for Attachment"
               },
-              "Spot Instance Failure": {
+              "Release Lock After Spot Failure": {
+                "Type": "Task",
+                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${StackBasename}-release-lock",
+                "ResultPath": "$.asg_lock",
+                "Next": "Unrecoverable Spot Instance Failure",
+                "Retry": [{
+                  "ErrorEquals": [ "States.ALL" ],
+                  "IntervalSeconds": 5,
+                  "MaxAttempts": 5,
+                  "BackoffRate": 2.5
+                }]
+              },
+              "Unrecoverable Spot Instance Failure": {
                 "Type": "Fail"
               },
-              "Success": {
-                "Type": "Succeed"
+              "Release Lock after Success": {
+                "Type": "Task",
+                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${StackBasename}-release-lock",
+                "ResultPath": "$.asg_lock",
+                "End": true,
+                "Retry": [{
+                  "ErrorEquals": [ "States.ALL" ],
+                  "IntervalSeconds": 5,
+                  "MaxAttempts": 5,
+                  "BackoffRate": 2.5
+                }]
               }
             }
           }

--- a/sam.yml
+++ b/sam.yml
@@ -16,6 +16,10 @@ Parameters:
     Type: String
     Default: "false"
     AllowedValues: ["false", "true"]
+  MaximumIterationCount:
+    Description: Maximum number of iterations
+    Type: Number
+    Default: 48
 
 Globals:
   Function:
@@ -55,6 +59,17 @@ Resources:
       Environment:
         Variables:
           SPOPTIMIZE_ACTION: 'ondemand-instance-healthy'
+
+  IncrementCountFn:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-increment-count"
+      Description: Increment iteration counter
+      Role: !Sub "arn:aws:iam::${AWS::AccountId}:role/${StackBasename}-iam-global-lambda-role"
+      CodeUri: ./target/lambda-pkg.zip
+      Environment:
+        Variables:
+          SPOPTIMIZE_ACTION: 'increment-count'
 
   RequestSpotInstanceFn:
     Type: AWS::Serverless::Function
@@ -127,11 +142,6 @@ Resources:
                 "SecondsPath": "$.init_sleep_interval",
                 "Next": "Test New ASG Instance"
               },
-              "Sleep after Failed Spot Request": {
-                "Type": "Wait",
-                "SecondsPath": "$.spot_failure_sleep_interval",
-                "Next": "Test New ASG Instance"
-              },
               "Test New ASG Instance": {
                 "Type": "Task",
                 "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${StackBasename}-ondemand-instance-healthy",
@@ -153,17 +163,20 @@ Resources:
                 },{
                   "Variable": "$.ondemand_instance_status",
                   "StringEquals": "Terminated",
-                  "Next": "Terminate Spot"
+                  "Next": "No Op"
                 },{
                   "Variable": "$.ondemand_instance_status",
                   "StringEquals": "Protected",
-                  "Next": "Terminate Spot"
+                  "Next": "No Op"
                 },{
                   "Variable": "$.ondemand_instance_status",
                   "StringEquals": "AutoScaling Group Disappeared",
-                  "Next": "Terminate Spot"
+                  "Next": "No Op"
                 }],
                 "Default": "Wait for New ASG Instance"
+              },
+              "No Op": {
+                "Type": "Succeed"
               },
               "Request Spot Instance": {
                 "Type": "Task",
@@ -203,9 +216,37 @@ Resources:
                 },{
                   "Variable": "$.spot_request_result",
                   "StringEquals": "Failure",
-                  "Next": "Sleep after Failed Spot Request"
+                  "Next": "Increment Failure Count"
                 }],
                 "Default": "Attach Spot Instance"
+              },
+              "Increment Failure Count": {
+                "Type": "Task",
+                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${StackBasename}-increment-count",
+                "Next": "Check Iteration Count?",
+                "ResultPath": "$.iteration_count",
+                "Retry": [{
+                  "ErrorEquals": [ "States.ALL" ],
+                  "IntervalSeconds": 1,
+                  "MaxAttempts": 5
+                }]
+              },
+              "Check Iteration Count?": {
+                "Type": "Choice",
+                "Choices": [{
+                  "Variable": "$.iteration_count",
+                  "NumericLessThanEquals": ${MaximumIterationCount},
+                  "Next": "Sleep after Failed Spot Request"
+                }],
+                "Default": "Execution Exhaustion"
+              },
+              "Execution Exhaustion": {
+                "Type": "Fail"
+              },
+              "Sleep after Failed Spot Request": {
+                "Type": "Wait",
+                "SecondsPath": "$.spot_failure_sleep_interval",
+                "Next": "Test New ASG Instance"
               },
               "Terminate Spot": {
                 "Type": "Task",
@@ -239,7 +280,7 @@ Resources:
                 },{
                   "Variable": "$.spot_attach_result",
                   "StringEquals": "Spot Instance Disappeared",
-                  "Next": "Sleep after Failed Spot Request"
+                  "Next": "Increment Failure Count"
                 },{
                   "Variable": "$.spot_attach_result",
                   "StringEquals": "OD Instance Disappeared Or Protected",
@@ -251,11 +292,11 @@ Resources:
                 },{
                   "Variable": "$.spot_attach_result",
                   "StringEquals": "Instance missing",
-                  "Next": "Sleep after Failed Spot Request"
+                  "Next": "Increment Failure Count"
                 },{
                   "Variable": "$.spot_attach_result",
                   "StringEquals": "Invalid instance",
-                  "Next": "Sleep after Failed Spot Request"
+                  "Next": "Increment Failure Count"
                 }],
                 "Default": "Wait for Attachment"
               },
@@ -285,13 +326,16 @@ Resources:
                 },{
                   "Variable": "$.spot_instance_status",
                   "StringEquals": "Terminated",
-                  "Next": "Sleep after Failed Spot Request"
+                  "Next": "Spot Instance Failure"
                 },{
                   "Variable": "$.spot_instance_status",
                   "StringEquals": "AutoScaling Group Disappeared",
                   "Next": "Terminate Spot"
                 }],
                 "Default": "Wait for Attachment"
+              },
+              "Spot Instance Failure": {
+                "Type": "Fail"
               },
               "Success": {
                 "Type": "Succeed"

--- a/sam.yml
+++ b/sam.yml
@@ -78,17 +78,6 @@ Resources:
         Variables:
           SPOPTIMIZE_ACTION: 'check-spot'
 
-  CheckAsgAndTagSpotFn:
-    Type: AWS::Serverless::Function
-    Properties:
-      FunctionName: !Sub "${AWS::StackName}-check-asg-and-tag-spot"
-      Description: Verifies that the autoscaling group still exists and tags the spot instance
-      Role: !Sub "arn:aws:iam::${AWS::AccountId}:role/${StackBasename}-iam-global-lambda-role"
-      CodeUri: ./target/lambda-pkg.zip
-      Environment:
-        Variables:
-          SPOPTIMIZE_ACTION: 'check-asg-and-tag-spot'
-
   AutoScalingGroupDisappearedFn:
     Type: AWS::Serverless::Function
     Properties:
@@ -99,17 +88,6 @@ Resources:
       Environment:
         Variables:
           SPOPTIMIZE_ACTION: 'term-spot-instance'
-
-  TermOnDemandBeforeAttachSpotFn:
-    Type: AWS::Serverless::Function
-    Properties:
-      FunctionName: !Sub "${AWS::StackName}-term-ondemand-attach-spot"
-      Description: Terminates launched autoscaling instance and attaches spot instance
-      Role: !Sub "arn:aws:iam::${AWS::AccountId}:role/${StackBasename}-iam-global-lambda-role"
-      CodeUri: ./target/lambda-pkg.zip
-      Environment:
-        Variables:
-          SPOPTIMIZE_ACTION: 'term-ondemand-attach-spot'
 
   AttachSpotBeforeTermOnDemandFn:
     Type: AWS::Serverless::Function
@@ -132,17 +110,6 @@ Resources:
       Environment:
         Variables:
           SPOPTIMIZE_ACTION: 'spot-instance-healthy'
-
-  TerminateOnDemandInstance:
-    Type: AWS::Serverless::Function
-    Properties:
-      FunctionName: !Sub "${AWS::StackName}-term-ondemand-instance"
-      Description: Terminates launched ondemand autoscaling instance
-      Role: !Sub "arn:aws:iam::${AWS::AccountId}:role/${StackBasename}-iam-global-lambda-role"
-      CodeUri: ./target/lambda-pkg.zip
-      Environment:
-        Variables:
-          SPOPTIMIZE_ACTION: 'term-ondemand-instance'
 
   SpotRequestor:
     Type: AWS::StepFunctions::StateMachine
@@ -186,20 +153,17 @@ Resources:
                 },{
                   "Variable": "$.ondemand_instance_status",
                   "StringEquals": "Terminated",
-                  "Next": "OD Instance Disappeared Or Protected"
+                  "Next": "Terminate Spot"
                 },{
                   "Variable": "$.ondemand_instance_status",
                   "StringEquals": "Protected",
-                  "Next": "OD Instance Disappeared Or Protected"
+                  "Next": "Terminate Spot"
                 },{
                   "Variable": "$.ondemand_instance_status",
-                  "StringEquals": "Auto-Scaling Group Disappeared",
-                  "Next": "AutoScaling Group Disappeared"
+                  "StringEquals": "AutoScaling Group Disappeared",
+                  "Next": "Terminate Spot"
                 }],
                 "Default": "Wait for New ASG Instance"
-              },
-              "OD Instance Disappeared Or Protected": {
-                "Type": "Succeed"
               },
               "Request Spot Instance": {
                 "Type": "Task",
@@ -241,42 +205,9 @@ Resources:
                   "StringEquals": "Failure",
                   "Next": "Sleep after Failed Spot Request"
                 }],
-                "Default": "Check ASG and Tag Spot"
+                "Default": "Attach Spot Instance"
               },
-              "Check ASG and Tag Spot": {
-                "Type": "Task",
-                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${StackBasename}-check-asg-and-tag-spot",
-                "Next": "Check ASG Status and Tag Spot?",
-                "ResultPath": "$.check_asg_result",
-                "Retry": [{
-                  "ErrorEquals": [ "States.ALL" ],
-                  "IntervalSeconds": 10,
-                  "MaxAttempts": 5,
-                  "BackoffRate": 15
-                }]
-              },
-              "Check ASG Status and Tag Spot?": {
-                "Type": "Choice",
-                "Choices": [{
-                  "Variable": "$.check_asg_result",
-                  "StringEquals": "No Capacity Available",
-                  "Next": "Term OnDemand Before Attach Spot"
-                },{
-                  "Variable": "$.check_asg_result",
-                  "StringEquals": "OnDemand Terminated",
-                  "Next": "OD Instance Disappeared Or Protected"
-                },{
-                  "Variable": "$.check_asg_result",
-                  "StringEquals": "Auto-Scaling Group Disappeared",
-                  "Next": "AutoScaling Group Disappeared"
-                },{
-                  "Variable": "$.check_asg_result",
-                  "StringEquals": "Spot Instance Disappeared",
-                  "Next": "Sleep after Failed Spot Request"
-                }],
-                "Default": "Attach Spot Before Term OnDemand"
-              },
-              "AutoScaling Group Disappeared": {
+              "Terminate Spot": {
                 "Type": "Task",
                 "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${StackBasename}-term-spot-instance",
                 "End": true,
@@ -287,19 +218,7 @@ Resources:
                   "BackoffRate": 15
                 }]
               },
-              "Term OnDemand Before Attach Spot": {
-                "Type": "Task",
-                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${StackBasename}-term-ondemand-attach-spot",
-                "ResultPath": "$.spot_attach_result",
-                "Next": "Check Attachment?",
-                "Retry": [{
-                  "ErrorEquals": [ "States.ALL" ],
-                  "IntervalSeconds": 10,
-                  "MaxAttempts": 5,
-                  "BackoffRate": 15
-                }]
-              },
-              "Attach Spot Before Term OnDemand": {
+              "Attach Spot Instance": {
                 "Type": "Task",
                 "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${StackBasename}-attach-spot",
                 "ResultPath": "$.spot_attach_result",
@@ -315,12 +234,20 @@ Resources:
                 "Type": "Choice",
                 "Choices": [{
                   "Variable": "$.spot_attach_result",
-                  "StringEquals": "AutoScaling group not sized correctly",
-                  "Next": "AutoScaling Group Disappeared"
+                  "StringEquals": "AutoScaling Group Disappeared",
+                  "Next": "Terminate Spot"
                 },{
                   "Variable": "$.spot_attach_result",
-                  "StringEquals": "Auto-Scaling Group Disappeared",
-                  "Next": "AutoScaling Group Disappeared"
+                  "StringEquals": "Spot Instance Disappeared",
+                  "Next": "Sleep after Failed Spot Request"
+                },{
+                  "Variable": "$.spot_attach_result",
+                  "StringEquals": "OD Instance Disappeared Or Protected",
+                  "Next": "Terminate Spot"
+                },{
+                  "Variable": "$.spot_attach_result",
+                  "StringEquals": "AutoScaling group not sized correctly",
+                  "Next": "Terminate Spot"
                 },{
                   "Variable": "$.spot_attach_result",
                   "StringEquals": "Instance missing",
@@ -354,28 +281,20 @@ Resources:
                 "Choices": [{
                   "Variable": "$.spot_instance_status",
                   "StringEquals": "Healthy",
-                  "Next": "Terminate OD Instance"
+                  "Next": "Success"
                 },{
                   "Variable": "$.spot_instance_status",
                   "StringEquals": "Terminated",
                   "Next": "Sleep after Failed Spot Request"
                 },{
                   "Variable": "$.spot_instance_status",
-                  "StringEquals": "Auto-Scaling Group Disappeared",
-                  "Next": "AutoScaling Group Disappeared"
+                  "StringEquals": "AutoScaling Group Disappeared",
+                  "Next": "Terminate Spot"
                 }],
                 "Default": "Wait for Attachment"
               },
-              "Terminate OD Instance": {
-                "Type": "Task",
-                "Resource": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${StackBasename}-term-ondemand-instance",
-                "End": true,
-                "Retry": [{
-                  "ErrorEquals": [ "States.ALL" ],
-                  "IntervalSeconds": 10,
-                  "MaxAttempts": 5,
-                  "BackoffRate": 15
-                }]
+              "Success": {
+                "Type": "Succeed"
               }
             }
           }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -39,6 +39,7 @@ if [[ -n $do_iam ]]; then
     # TODO primary/global region?
     echo 'Deploying IAM stack ...'
     aws cloudformation deploy \
+        --parameter-overrides StackBasename=$stack_basename \
         --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
         --template-file "$basedir/iam-global.yml" \
         --stack-name "$stack_basename-iam-global"
@@ -68,7 +69,7 @@ if [[ -n $do_sam ]]; then
     echo
     echo 'Deploying Spoptimize ...'
     aws cloudformation deploy \
-        --parameter-overrides DebugLambdas=$lambda_debug_log \
+        --parameter-overrides StackBasename=$stack_basename DebugLambdas=$lambda_debug_log \
         --template-file "$basedir/target/sam_output.yml" \
         --stack-name "$stack_basename" || exit $?
 fi

--- a/spoptimize/asg_helper.py
+++ b/spoptimize/asg_helper.py
@@ -1,6 +1,5 @@
 import boto3
 import logging
-import os
 import re
 
 from botocore.exceptions import ClientError
@@ -8,10 +7,6 @@ from botocore.exceptions import ClientError
 logger = logging.getLogger()
 logging.getLogger('boto3').setLevel(logging.WARNING)
 logging.getLogger('botocore').setLevel(logging.WARNING)
-
-# this adds vendored directory to the Python import path
-here = os.path.dirname(os.path.realpath(__file__))
-mocks_dir = os.path.join(here, 'resources', 'mock_data')
 
 autoscaling = boto3.client('autoscaling')
 

--- a/spoptimize/asg_helper.py
+++ b/spoptimize/asg_helper.py
@@ -98,7 +98,7 @@ def attach_instance(asg_name, instance_id):
             return 'AutoScaling group not sized correctly'
         if re.match(r'AutoScalingGroup name not found', c.response['Error']['Message']):
             logger.warning(c.response['Error']['Message'])
-            return 'Auto-Scaling Group Disappeared'
+            return 'AutoScaling Group Disappeared'
         if re.match(r'Instance .* is not in correct state', c.response['Error']['Message']):
             logger.error(c.response['Error']['Message'])
             return 'Instance missing'

--- a/spoptimize/ec2_helper.py
+++ b/spoptimize/ec2_helper.py
@@ -29,9 +29,9 @@ def terminate_instance(instance_id):
 
 
 def tag_instance(instance_id, orig_instance_id, resource_tags=[]):
-    logger.info('Tagging EC2 instance {0} with {1}'.format(instance_id, resource_tags))
     my_tags = copy.copy(resource_tags)
-    my_tags.append({'Key': 'spoptimize:orig_instance_id', 'Value': orig_instance_id})
+    my_tags.append({'Key': 'spoptimize:orig_instance_id', 'Value': orig_instance_id or 'UNKNWON'})
+    logger.info('Tagging EC2 instance {0} with {1}'.format(instance_id, resource_tags))
     try:
         ec2.create_tags(Resources=[instance_id], Tags=my_tags)
     except ClientError as c:

--- a/spoptimize/stepfns.py
+++ b/spoptimize/stepfns.py
@@ -1,9 +1,12 @@
 # import json
 import logging
 import re
+
+from datetime import datetime, timedelta
 from random import random
 
 import asg_helper
+import ddb_lock_helper
 import ec2_helper
 import spot_helper
 # import util
@@ -150,3 +153,31 @@ def attach_spot_instance(asg_dict, spot_instance_id, ondemand_instance_id):
 def terminate_ec2_instance(instance_id):
     if instance_id:
         return ec2_helper.terminate_instance(instance_id)
+
+
+def acquire_lock(table_name, group_name, my_execution_arn):
+    logger.info('Acquiring lock for {}'.format(group_name))
+    logger.debug('My execution ARN is {}'.format(my_execution_arn))
+    ttl = int((timedelta(days=7) + datetime.now() - datetime.utcfromtimestamp(0)).total_seconds())
+    if ddb_lock_helper.put_item(table_name, group_name, my_execution_arn, ttl):
+        logger.info('Lock for {} Acquired'.format(group_name))
+        return True
+    current_owner = ddb_lock_helper.get_item(table_name, group_name)
+    if current_owner == my_execution_arn:
+        logger.info('Lock for {} Already Acquired'.format(group_name))
+        return True
+    if ddb_lock_helper.is_execution_running(current_owner):
+        logger.info('Lock for {0} belongs to {1}'.format(group_name, current_owner))
+        return False
+    logger.info('Found stale lock for {0}  belonging to {1}'.format(group_name, current_owner))
+    if ddb_lock_helper.put_item(table_name, group_name, my_execution_arn, ttl, current_owner):
+        logger.info('Lock for {} Acquired'.format(group_name))
+        return True
+    logger.warning('Unable to acquire lock for {}'.format(group_name))
+    return False
+
+
+def release_lock(table_name, group_name, my_execution_arn):
+    logger.info('Releasing lock for {}'.format(group_name))
+    logger.debug('My execution ARN is {}'.format(my_execution_arn))
+    ddb_lock_helper.delete_item(table_name, group_name, my_execution_arn)

--- a/spoptimize/stepfns.py
+++ b/spoptimize/stepfns.py
@@ -69,6 +69,7 @@ def init_machine_state(sns_message):
         logger.warning('Autoscaling Group {} has a fixed size'.format(group_name))
         return ({}, 'AutoScaling Group has fixed size')
     return ({
+        'iteration_count': 0,
         'ondemand_instance_id': instance_id,
         'launch_subnet_id': subnet_details['Subnet ID'],
         'launch_az': subnet_details['Availability Zone'],

--- a/spoptimize/test_asg_helper.py
+++ b/spoptimize/test_asg_helper.py
@@ -228,7 +228,7 @@ class TestAttachInstance(unittest.TestCase):
 
     def test_attach_instance_invalid_state(self):
         logger.debug('TestAttachInstance.test_attach_instance_invalid_state')
-        expected_res = 'Auto-Scaling Group Disappeared'
+        expected_res = 'AutoScaling Group Disappeared'
         self.mock_attrs['attach_instances.side_effect'] = ClientError({
             'Error': {
                 'Code': 'ValidationError',

--- a/spoptimize/test_ec2_helper.py
+++ b/spoptimize/test_ec2_helper.py
@@ -22,9 +22,11 @@ for file in os.listdir(mocks_dir):
 
 class TestTerminateInstance(unittest.TestCase):
 
+    def setUp(self):
+        ec2_helper.ec2 = Mock()
+
     def test_terminate_instance(self):
         logger.debug('TestTerminateInstance.terminate_instance')
-        ec2_helper.ec2 = Mock()
         ec2_helper.terminate_instance('i-abcd123')
         ec2_helper.ec2.terminate_instances.assert_called()
 
@@ -43,9 +45,11 @@ class TestTerminateInstance(unittest.TestCase):
 
 class TestTagInstance(unittest.TestCase):
 
+    def setUp(self):
+        ec2_helper.ec2 = Mock()
+
     def test_tag_instance(self):
         logger.debug('TestEc2Helper.test_tag_instance')
-        ec2_helper.ec2 = Mock()
         res = ec2_helper.tag_instance('i-9999999', 'i-abcd123', [{'Key': 'testkey', 'Value': 'testval'}])
         ec2_helper.ec2.create_tags.assert_called_once_with(
             Resources=['i-9999999'],
@@ -55,7 +59,6 @@ class TestTagInstance(unittest.TestCase):
 
     def test_tag_instance_no_tags(self):
         logger.debug('TestTagInstance.test_tag_instance_no_tags')
-        ec2_helper.ec2 = Mock()
         res = ec2_helper.tag_instance('i-9999999', 'i-abcd123', [])
         ec2_helper.ec2.create_tags.assert_called_once_with(
             Resources=['i-9999999'],
@@ -79,6 +82,7 @@ class TestTagInstance(unittest.TestCase):
 class TestIsInstanceRunning(unittest.TestCase):
 
     def setUp(self):
+        ec2_helper.ec2 = Mock()
         self.mock_attrs = copy.deepcopy(mock_attrs)
 
     def test_running_instance(self):

--- a/spoptimize/test_stepfns.py
+++ b/spoptimize/test_stepfns.py
@@ -30,6 +30,7 @@ with open(os.path.join(mocks_dir, 'asg-launch-notification.json')) as j:
 launch_notification = json.loads(sns_notification['Message'])
 randseed = (datetime.datetime.now() - datetime.datetime.utcfromtimestamp(0)).total_seconds()
 state_machine_init = {
+    'iteration_count': 0,
     'ondemand_instance_id': launch_notification['EC2InstanceId'],
     'launch_subnet_id': launch_notification['Details']['Subnet ID'],
     'launch_az': launch_notification['Details']['Availability Zone'],


### PR DESCRIPTION
- Somewhat simplifies step-function flow. Instead of trying to attach, wait, then terminate the original instance, we now attach & term (or term & attach) immediately. This will avoid looping between the ASG and Spoptimize.
- Adds a counter after failed spot requests. If that loop occurs too many times, the execution will eventually fail. (Also use that count in the client-token of the spot request.)
- Implements exclusive locking (#2) of an autoscaling group. This ensures only one instance will be replaced at a time.
- Also includes miscellaneous fixes and tweaks.