### PR TITLE
Add handler for spot interruption warnings

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -3,6 +3,7 @@ import json
 
 from os import environ
 
+import spoptimize.spot_warning as spot_warning
 import spoptimize.stepfns as stepfns
 import spoptimize.util as util
 from spoptimize.logging_helper import logging
@@ -107,3 +108,12 @@ def handler(event, context):
     # 'An error occurred during JSON serialization of response' Exception
     util.walk_dict_for_datetime(retval)
     return retval
+
+
+def spot_warning_handler(event, context):
+    logger.debug('EVENT: {}'.format(json.dumps(event, indent=2, default=util.json_dumps_converter)))
+    if environ.get('SPOPTIMIZE_DEBUG', 'false').lower() not in ['0', 'no', 'false']:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
+    spot_warning.process_warning_event(event)

--- a/sam.yml
+++ b/sam.yml
@@ -66,6 +66,22 @@ Resources:
           Properties:
             Topic: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${SnsTopicName}"
 
+  SpotWarningFn:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-spot-warning"
+      Description: Processes EC2 spot instance warnings and terminates via autoscaling API
+      Role: !Sub "arn:aws:iam::${AWS::AccountId}:role/${StackBasename}-iam-global-lambda-role"
+      CodeUri: ./target/lambda-pkg.zip
+      Handler: handler.spot_warning_handler
+      Events:
+        SpotWarningForSpoptimize:
+          Type: CloudWatchEvent
+          Properties:
+            Pattern:
+              source: ["aws.ec2"]
+              detail-type: ["EC2 Spot Instance Interruption Warning"]
+
   TestNewAsgInstanceFn:
     Type: AWS::Serverless::Function
     Properties:

--- a/spoptimize/spot_warning.py
+++ b/spoptimize/spot_warning.py
@@ -1,0 +1,24 @@
+import json
+import logging
+
+import asg_helper
+import ec2_helper
+import util
+
+logger = logging.getLogger()
+
+
+def process_warning_event(event):
+    event_source = event.get('source')
+    event_detail_type = event.get('detail-type')
+    if event_source != 'aws.ec2' or event_detail_type != 'EC2 Spot Instance Interruption Warning':
+        raise Exception('Malformed event: {}'.format(json.dumps(event, indent=2, default=util.json_dumps_converter)))
+    if event['detail']['instance-action'] != 'terminate':
+        raise Exception('Invalid or unknown event: {}'.format(json.dumps(event, indent=2, default=util.json_dumps_converter)))
+    instance_id = event['detail']['instance-id']
+    logger.info('EC2 Spot Interruption Warning received for {}'.format(instance_id))
+    if ec2_helper.is_spoptimize_instance(instance_id):
+        logger.info('{} was launched by spoptimize ... terminating via autoscaling API'.format(instance_id))
+        asg_helper.terminate_instance(instance_id, decrement_cap=False)
+    else:
+        logger.info('{} was not launched by spoptimize ... ignoring'.format(instance_id))

--- a/spoptimize/test_spot_warning.py
+++ b/spoptimize/test_spot_warning.py
@@ -1,0 +1,63 @@
+import copy
+import unittest
+from mock import Mock
+
+import spot_warning
+from logging_helper import logging, setup_stream_handler
+
+logger = logging.getLogger()
+logger.addHandler(logging.NullHandler())
+
+sample_warning_event = {
+    'account': '123456789012',
+    'source': 'aws.ec2',
+    'detail': {
+        'instance-action': 'terminate',
+        'instance-id': 'i-02aaeba0211010942'
+    },
+    'detail-type': 'EC2 Spot Instance Interruption Warning',
+    'id': 'b082f84f-569f-cc21-f89d-3beb103b5c9e',
+    'region': 'us-east-1',
+    'resources': ['arn:aws:ec2:us-east-1c:instance/i-08cb4315e07e136ef'],
+    'time': '2018-01-29T23:25:20Z',
+    'version': '0'
+}
+
+
+class TestProcessSpotWarningEvent(unittest.TestCase):
+
+    def setUp(self):
+        self.event = copy.deepcopy(sample_warning_event)
+        spot_warning.asg_helper = Mock()
+        spot_warning.ec2_helper = Mock()
+
+    def test_malformed_event(self):
+        logger.debug('TestProcessSpotWarningEvent.test_malformed_event')
+        with self.assertRaises(Exception):
+            spot_warning.process_warning_event({})
+
+    def test_invalid_event(self):
+        logger.debug('TestProcessSpotWarningEvent.test_invalid_event')
+        self.event['detail']['instance-action'] = 'unknown'
+        with self.assertRaises(Exception):
+            spot_warning.process_warning_event(self.event)
+
+    def test_not_spoptimize_instance(self):
+        logger.debug('TestProcessSpotWarningEvent.test_not_spoptimize_instance')
+        spot_warning.ec2_helper = Mock(**{'is_spoptimize_instance.return_value': False})
+        spot_warning.process_warning_event(self.event)
+        spot_warning.ec2_helper.is_spoptimize_instance.assert_called_once_with(self.event['detail']['instance-id'])
+        spot_warning.asg_helper.terminate_instance.assert_not_called()
+
+    def test_terminate_spoptimize_instance(self):
+        logger.debug('TestProcessSpotWarningEvent.test_terminate_spoptimize_instance')
+        spot_warning.ec2_helper = Mock(**{'is_spoptimize_instance.return_value': True})
+        spot_warning.process_warning_event(self.event)
+        spot_warning.ec2_helper.is_spoptimize_instance.assert_called_once_with(self.event['detail']['instance-id'])
+        spot_warning.asg_helper.terminate_instance.assert_called_once_with(self.event['detail']['instance-id'], decrement_cap=False)
+
+
+if __name__ == '__main__':
+    logger.setLevel(logging.DEBUG)
+    setup_stream_handler()
+    unittest.main()


### PR DESCRIPTION
Wires up Spot Instance Interruption Warnings via CloudWatch events to a new lambda that terminates the instance via the autoscaling API (only if it was launched by Spoptimize)

[Closes #3]