### PR TITLE
Catch MaxSpotInstanceCountExceeded error

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -65,7 +65,11 @@ def handler(event, context):
 
     # Check Spot Request
     elif action == 'check-spot':
-        retval = stepfns.get_spot_request_status(event['spot_request']['SpotInstanceRequestId'])
+        if event['spot_request'].get('SpoptimizeError'):
+            logger.info('Spot request error'.format(event['spot_request']['SpoptimizeError']))
+            retval = 'Failure'
+        else:
+            retval = stepfns.get_spot_request_status(event['spot_request']['SpotInstanceRequestId'])
 
     # AutoScaling Group Disappeared
     elif action == 'term-spot-instance':

--- a/spoptimize/test_spot_helper.py
+++ b/spoptimize/test_spot_helper.py
@@ -201,6 +201,19 @@ class TestRequestSpotInstance(unittest.TestCase):
         )
         self.assertDictEqual(spot_req_dict, expected_dict)
 
+    def test_max_spot_instance_count(self):
+        logger.debug('TestRequestSpotInstance.test_max_spot_instance_count')
+        self.mock_attrs['request_spot_instances.side_effect'] = ClientError({
+            'Error': {
+                'Code': 'MaxSpotInstanceCountExceeded',
+                'Message': 'Max spot instance count exceeded'
+            }
+        }, 'RequestSpotInstances')
+        spot_helper.ec2 = Mock(**self.mock_attrs)
+        expected_dict = {'SpoptimizeError': 'MaxSpotInstanceCountExceeded'}
+        spot_req_dict = spot_helper.request_spot_instance(self.launch_config, self.az, self.subnet_id, self.client_token)
+        self.assertDictEqual(spot_req_dict, expected_dict)
+
 
 class TestGetSpotRequestStatus(unittest.TestCase):
 


### PR DESCRIPTION
Catch `Max spot instance count exceeded` error so that execution retries spot request.