### PR TITLE
Centralize static strings in a module

### DIFF
--- a/spoptimize/asg_helper.py
+++ b/spoptimize/asg_helper.py
@@ -12,6 +12,10 @@ autoscaling = boto3.client('autoscaling')
 
 
 def describe_asg(asg_name):
+    '''
+    Calls autoscaling.describe_auto_scaling_groups()
+    Returns a dict containing autoscaling group description; Empty dict for group not found
+    '''
     logger.debug('Querying for autoscaling group {}'.format(asg_name))
     resp = autoscaling.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])
     if len(resp['AutoScalingGroups']):
@@ -22,6 +26,10 @@ def describe_asg(asg_name):
 
 
 def get_launch_config(asg_name):
+    '''
+    Fetches the launch configuration of the specified autoscaling group
+    Returns a dict containing the launch configuration; Empty dict for group or luanch-config not found
+    '''
     logger.debug('Querying for launch config for autoscaling group {}'.format(asg_name))
     asg = describe_asg(asg_name)
     if not asg:
@@ -37,6 +45,10 @@ def get_launch_config(asg_name):
 
 
 def get_instance_status(instance_id):
+    '''
+    Fetches the autoscaling health status of instance_id
+    Returns a string
+    '''
     logger.debug('Fetching autoscaling health status for {}'.format(instance_id))
     resp = autoscaling.describe_auto_scaling_instances(InstanceIds=[instance_id])
     # instance is terminated or detatched if empty
@@ -72,6 +84,10 @@ def get_instance_status(instance_id):
 
 
 def terminate_instance(instance_id, decrement_cap):
+    '''
+    Terminates instance_id via the autoscaling api
+    No return value
+    '''
     logger.info('Terminating autoscaling instance {0}; decrement capacity: {1}'.format(instance_id, decrement_cap))
     try:
         autoscaling.terminate_instance_in_auto_scaling_group(
@@ -84,6 +100,10 @@ def terminate_instance(instance_id, decrement_cap):
 
 
 def attach_instance(asg_name, instance_id):
+    '''
+    Attaches instance_id to the specified autoscaling group
+    Returns a string describing the status of the attachment
+    '''
     logger.info('Attaching {0} to AutoScaling group {1}'.format(instance_id, asg_name))
     try:
         autoscaling.attach_instances(InstanceIds=[instance_id], AutoScalingGroupName=asg_name)

--- a/spoptimize/ddb_lock_helper.py
+++ b/spoptimize/ddb_lock_helper.py
@@ -15,6 +15,10 @@ sfn = boto3.client('stepfunctions')
 
 
 def put_item(table_name, group_name, my_execution_arn, ttl, prev_execution_arn=None):
+    '''
+    Writes a lock to the dynamodb table
+    Returns put_item response if successful; None if put_item condition check fails
+    '''
     item = {
         'group_name': {'S': group_name},
         'execution_arn': {'S': my_execution_arn},
@@ -36,6 +40,10 @@ def put_item(table_name, group_name, my_execution_arn, ttl, prev_execution_arn=N
 
 
 def get_item(table_name, group_name):
+    '''
+    Fetches a lock record from the dynamodb table
+    Returns the step function execution arn of the locked record
+    '''
     logger.debug('Fetching {0} from DDB table {1}'.format(group_name, table_name))
     resp = ddb.get_item(TableName=table_name, Key={'group_name': {'S': group_name}}, ConsistentRead=True)
     item = resp.get('Item', {})
@@ -47,6 +55,10 @@ def get_item(table_name, group_name):
 
 
 def delete_item(table_name, group_name, my_execution_arn):
+    '''
+    Deletes a lock record from the dynamodb table
+    Returns delete_item response
+    '''
     key = {'group_name': {'S': group_name}}
     logger.debug('Deleting DDB item from table {0} [{1}]: {2}'.format(
         json.dumps(key, default=util.json_dumps_converter), my_execution_arn, table_name))
@@ -55,6 +67,10 @@ def delete_item(table_name, group_name, my_execution_arn):
 
 
 def is_execution_running(execution_arn):
+    '''
+    Fetches status of step function execution_arn
+    Returns True if running; False otherwise
+    '''
     logger.debug('Fetching state machine execution status of {}'.format(execution_arn))
     try:
         resp = sfn.describe_execution(executionArn=execution_arn)

--- a/spoptimize/ec2_helper.py
+++ b/spoptimize/ec2_helper.py
@@ -18,6 +18,10 @@ ec2 = boto3.client('ec2')
 
 
 def terminate_instance(instance_id):
+    '''
+    Terminates instance_id via the EC2 API
+    No return value
+    '''
     logger.info('Terminating EC2 Instance {}'.format(instance_id))
     try:
         ec2.terminate_instances(InstanceIds=[instance_id])
@@ -29,6 +33,10 @@ def terminate_instance(instance_id):
 
 
 def tag_instance(instance_id, orig_instance_id, resource_tags=[]):
+    '''
+    Tags instance_id using tags of orig_instance_id and resource_tags
+    Returns True if successful, False if not
+    '''
     my_tags = copy.copy(resource_tags)
     my_tags.append({'Key': 'spoptimize:orig_instance_id', 'Value': orig_instance_id or 'UNKNWON'})
     logger.info('Tagging EC2 instance {0} with {1}'.format(instance_id, resource_tags))
@@ -44,6 +52,10 @@ def tag_instance(instance_id, orig_instance_id, resource_tags=[]):
 
 
 def is_instance_running(instance_id):
+    '''
+    Checks the state of instance_id
+    Returns True if the instance is running; False if not
+    '''
     logger.debug('Fetching EC2 instance state of {}'.format(instance_id))
     try:
         resp = ec2.describe_instances(InstanceIds=[instance_id])
@@ -60,6 +72,10 @@ def is_instance_running(instance_id):
 
 
 def is_spoptimize_instance(instance_id):
+    '''
+    Uses instance_id's tags to see if it was launched by spoptimize
+    Returns True/False
+    '''
     logger.debug('Determining if {} was launched by Spoptimize'.format(instance_id))
     try:
         resp = ec2.describe_instances(InstanceIds=[instance_id])

--- a/spoptimize/spot_helper.py
+++ b/spoptimize/spot_helper.py
@@ -21,6 +21,9 @@ iam = boto3.client('iam')
 
 
 def get_instance_profile_arn(instance_profile):
+    '''
+    Returns the ARN of instance_profile
+    '''
     if instance_profile[:12] == 'arn:aws:iam:':
         return instance_profile
     logger.info('Fetching arn for instance-profile {}'.format(instance_profile))
@@ -28,6 +31,10 @@ def get_instance_profile_arn(instance_profile):
 
 
 def gen_launch_specification(launch_config, avail_zone, subnet_id):
+    '''
+    Uses an autoscaling launch configuration to generate an EC2 launch specification
+    Returns a dict
+    '''
     logger.debug('Converting asg launch config to ec2 launch spec')
     # logger.debug('Launch Config: {}'.format(json.dumps(launch_config, indent=2, default=util.json_dumps_converter)))
     spot_launch_specification = {
@@ -59,6 +66,10 @@ def gen_launch_specification(launch_config, avail_zone, subnet_id):
 
 
 def request_spot_instance(launch_config, avail_zone, subnet_id, client_token):
+    '''
+    Requests a spot instance
+    Returns a dict containing the spot instance request response
+    '''
     logger.info('Requesting spot instance in {0}/{1}'.format(avail_zone, subnet_id))
     launch_spec = gen_launch_specification(launch_config, avail_zone, subnet_id)
     try:
@@ -74,6 +85,10 @@ def request_spot_instance(launch_config, avail_zone, subnet_id, client_token):
 
 
 def get_spot_request_status(spot_request_id):
+    '''
+    Fetches the spot instance request status of spot_request_id
+    Returns instance-id of spot instance if running; 'Pending' or 'Failure' otherwise
+    '''
     logger.debug('Checking status of spot request {}'.format(spot_request_id))
     try:
         resp = ec2.describe_spot_instance_requests(SpotInstanceRequestIds=[spot_request_id])

--- a/spoptimize/spot_helper.py
+++ b/spoptimize/spot_helper.py
@@ -6,6 +6,7 @@ import os
 
 from botocore.exceptions import ClientError
 
+import stepfn_strings as strs
 import util
 
 logger = logging.getLogger()
@@ -95,7 +96,7 @@ def get_spot_request_status(spot_request_id):
     except ClientError as c:
         if c.response['Error']['Code'] == 'InvalidSpotInstanceRequestID.NotFound':
             logger.info('Spot instance request {} does not exist'.format(spot_request_id))
-            return 'Failure'
+            return strs.spot_request_failure
         raise
     # logger.debug('Spot request status response: {}'.format(resp))
     spot_request = resp['SpotInstanceRequests'][0]
@@ -104,6 +105,6 @@ def get_spot_request_status(spot_request_id):
         return spot_request['InstanceId']
     if spot_request.get('State', 'unknown') in ['closed', 'cancelled', 'failed']:
         logger.info('Spot instance request {0} is {1}'.format(spot_request_id, spot_request['State']))
-        return 'Failure'
+        return strs.spot_request_failure
     logger.info('Spot instance request {0} is pending with state {1}'.format(spot_request_id, spot_request['State']))
-    return 'Pending'
+    return strs.spot_request_pending

--- a/spoptimize/spot_helper.py
+++ b/spoptimize/spot_helper.py
@@ -1,5 +1,4 @@
 import boto3
-import datetime
 import json
 import logging
 import os

--- a/spoptimize/stepfn_strings.py
+++ b/spoptimize/stepfn_strings.py
@@ -1,0 +1,16 @@
+success = 'Success'
+
+asg_instance_healthy = 'Healthy'
+asg_instance_terminated = 'Terminated'
+asg_instance_protected = 'Protected'
+asg_instance_pending = 'Pending'
+asg_instance_missing = 'Instance missing'
+asg_instance_invalid = 'Invalid instance'
+asg_disappeared = 'AutoScaling Group Disappeared'
+asg_not_sized_correctly = 'AutoScaling group not sized correctly'
+
+spot_request_failure = 'Failure'
+spot_request_pending = 'Pending'
+
+spot_instance_disappeared = 'Spot Instance Disappeared'
+od_instance_disappeared = 'OD Instance Disappeared Or Protected'

--- a/spoptimize/test_spot_helper.py
+++ b/spoptimize/test_spot_helper.py
@@ -8,6 +8,7 @@ from botocore.exceptions import ClientError
 from mock import Mock
 
 import spot_helper
+import stepfn_strings as strs
 # import util
 from logging_helper import logging, setup_stream_handler
 
@@ -234,7 +235,7 @@ class TestGetSpotRequestStatus(unittest.TestCase):
 
     def test_get_spot_request_status_not_found(self):
         logger.debug('TestGetSpotRequest_status.test_get_spot_request_status_not_found')
-        expected_res = 'Failure'
+        expected_res = strs.spot_request_failure
         self.mock_attrs['describe_spot_instance_requests.side_effect'] = ClientError({
             'Error': {
                 'Code': 'InvalidSpotInstanceRequestID.NotFound',
@@ -247,7 +248,7 @@ class TestGetSpotRequestStatus(unittest.TestCase):
 
     def test_get_spot_request_status_failure(self):
         logger.debug('TestGetSpotRequest_status.test_get_spot_request_status_failure')
-        expected_res = 'Failure'
+        expected_res = strs.spot_request_failure
         self.mock_attrs['describe_spot_instance_requests.return_value']['SpotInstanceRequests'][0]['Status']['Message'] = 'Dummy message'
         self.mock_attrs['describe_spot_instance_requests.return_value']['SpotInstanceRequests'][0]['Status']['Code'] = 'dummy-code'
         for state in ['closed', 'cancelled', 'failed']:
@@ -258,7 +259,7 @@ class TestGetSpotRequestStatus(unittest.TestCase):
 
     def test_get_spot_request_status_pending(self):
         logger.debug('TestGetSpotRequest_status.test_get_spot_request_status_failure')
-        expected_res = 'Pending'
+        expected_res = strs.spot_request_pending
         self.mock_attrs['describe_spot_instance_requests.return_value']['SpotInstanceRequests'][0]['Status']['Message'] = 'Your Spot request has been submitted for review, and is pending evaluation.'
         self.mock_attrs['describe_spot_instance_requests.return_value']['SpotInstanceRequests'][0]['Status']['Code'] = 'pending-evaluation'
         self.mock_attrs['describe_spot_instance_requests.return_value']['SpotInstanceRequests'][0]['State'] = 'open'

--- a/spoptimize/test_stepfns.py
+++ b/spoptimize/test_stepfns.py
@@ -9,6 +9,7 @@ import unittest
 from mock import Mock
 
 import stepfns
+import stepfn_strings as strs
 from logging_helper import logging, setup_stream_handler
 
 logger = logging.getLogger()
@@ -158,7 +159,7 @@ class TestAsgInstanceStatus(unittest.TestCase):
         res = stepfns.asg_instance_state(self.asg_dict, 'i-abcd123')
         stepfns.asg_helper.describe_asg.assert_called()
         stepfns.asg_helper.get_instance_status.assert_called()
-        self.assertEqual(res, 'Healthy')
+        self.assertEqual(res, strs.asg_instance_healthy)
 
     def test_unknown_asg(self):
         logger.debug('TestAsgInstanceStatus.test_unknown_asg')
@@ -169,7 +170,7 @@ class TestAsgInstanceStatus(unittest.TestCase):
         res = stepfns.asg_instance_state(self.asg_dict, 'i-abcd123')
         stepfns.asg_helper.describe_asg.assert_called()
         stepfns.asg_helper.get_instance_status.assert_not_called()
-        self.assertEqual(res, 'AutoScaling Group Disappeared')
+        self.assertEqual(res, strs.asg_disappeared)
 
 
 class TestRequestSpotInstance(unittest.TestCase):
@@ -209,7 +210,7 @@ class TestGetSpotRequestStatus(unittest.TestCase):
         res = stepfns.get_spot_request_status('sir-test')
         stepfns.spot_helper.get_spot_request_status.assert_called_with('sir-test')
         stepfns.ec2_helper.is_instance_running.assert_not_called()
-        self.assertEqual(res, 'Pending')
+        self.assertEqual(res, strs.spot_request_pending)
 
     def test_get_spot_request_status_running_instance(self):
         logger.debug('TestGetSpotRequestStatus.test_get_spot_request_status')
@@ -227,7 +228,7 @@ class TestGetSpotRequestStatus(unittest.TestCase):
         res = stepfns.get_spot_request_status('sir-test')
         stepfns.spot_helper.get_spot_request_status.assert_called_with('sir-test')
         stepfns.ec2_helper.is_instance_running.assert_called_once_with('i-abcd123')
-        self.assertEqual(res, 'Pending')
+        self.assertEqual(res, strs.spot_request_pending)
 
     def test_get_spot_request_status_unknown_instance(self):
         logger.debug('TestGetSpotRequestStatus.test_get_spot_request_status')
@@ -236,7 +237,7 @@ class TestGetSpotRequestStatus(unittest.TestCase):
         res = stepfns.get_spot_request_status('sir-test')
         stepfns.spot_helper.get_spot_request_status.assert_called_with('sir-test')
         stepfns.ec2_helper.is_instance_running.assert_called_once_with('i-abcd123')
-        self.assertEqual(res, 'Pending')
+        self.assertEqual(res, strs.spot_request_pending)
 
 
 class TestAttachSpotInstance(unittest.TestCase):
@@ -250,7 +251,7 @@ class TestAttachSpotInstance(unittest.TestCase):
 
     def test_no_capacity(self):
         logger.debug('TestAttachSpotInstance.test_no_capacity')
-        expected_res = 'Success'
+        expected_res = strs.success
         self.asg_dict['DesiredCapacity'] = self.asg_dict['MaxSize']
         stepfns.asg_helper = Mock(**{
             'describe_asg.return_value': self.asg_dict,
@@ -272,7 +273,7 @@ class TestAttachSpotInstance(unittest.TestCase):
 
     def test_capacity_available(self):
         logger.debug('TestAttachSpotInstance.test_capacity_available')
-        expected_res = 'Success'
+        expected_res = strs.success
         expected_tags = [{'Key': x['Key'], 'Value': x['Value']} for x in self.asg_dict['Tags']
                          if x.get('PropagateAtLaunch', False) and x.get('Key', '').split(':')[0] != 'aws']
         stepfns.asg_helper = Mock(**{
@@ -295,7 +296,7 @@ class TestAttachSpotInstance(unittest.TestCase):
 
     def test_no_asg(self):
         logger.debug('TestAttachSpotInstance.test_no_asg')
-        expected_res = 'AutoScaling Group Disappeared'
+        expected_res = strs.asg_disappeared
         stepfns.asg_helper = Mock(**{
             'describe_asg.return_value': {}
         })
@@ -309,7 +310,7 @@ class TestAttachSpotInstance(unittest.TestCase):
 
     def test_spot_disappeared(self):
         logger.debug('TestAttachSpotInstance.test_spot_disappeared')
-        expected_res = 'Spot Instance Disappeared'
+        expected_res = strs.spot_instance_disappeared
         stepfns.asg_helper = Mock(**{
             'describe_asg.return_value': self.asg_dict,
             'get_instance_status.return_value': 'Healthy'
@@ -327,7 +328,7 @@ class TestAttachSpotInstance(unittest.TestCase):
 
     def test_od_disappeared_or_protected(self):
         logger.debug('TestAttachSpotInstance.test_od_disappeared_or_protected')
-        expected_res = 'OD Instance Disappeared Or Protected'
+        expected_res = strs.od_instance_disappeared
         stepfns.asg_helper = Mock(**{
             'describe_asg.return_value': self.asg_dict,
             'get_instance_status.return_value': 'Protected'


### PR DESCRIPTION
* Move all of the strings that are used by Choice steps in the step functions into a module.
* Adds docstrings to functions that did not have any

Related to #22