### PR TITLE
Support security-group names in launch-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,7 @@ The Step Function execution manages the execution of Lambda functions which perf
 Screenshot of a successful execution:
 ![AWS Step Function execution](docs/images/readme-step-fn-sample-execution.png "Spoptimize step function execution")
 
+## Notes
+
+* Auto-Scaling groups that deploy EC2 instances to VPCs are tested. Auto-Scaling groups in EC2-Classic should
+  work, but is not tested.

--- a/iam-global.yml
+++ b/iam-global.yml
@@ -67,6 +67,7 @@ Resources:
               - ec2:CreateTags
               - ec2:DescribeSpotInstanceRequests
               - ec2:DescribeSpotPriceHistory
+              - ec2:DescribeSecurityGroups
               - ec2:DescribeInstances
               - ec2:DescribeTags
               - ec2:RequestSpotInstances

--- a/spoptimize/resources/mock_data/ec2/describe_security_groups.json
+++ b/spoptimize/resources/mock_data/ec2/describe_security_groups.json
@@ -1,0 +1,52 @@
+{
+    "SecurityGroups": [
+        {
+            "IpPermissionsEgress": [
+                {
+                    "IpProtocol": "-1",
+                    "PrefixListIds": [],
+                    "IpRanges": [
+                        {
+                            "CidrIp": "0.0.0.0/0"
+                        }
+                    ],
+                    "UserIdGroupPairs": [],
+                    "Ipv6Ranges": []
+                }
+            ],
+            "Description": "Generic Security Group",
+            "IpPermissions": [
+                {
+                    "PrefixListIds": [],
+                    "FromPort": 22,
+                    "IpRanges": [
+                        {
+                            "CidrIp": "0.0.0.0/32"
+                        }
+                    ],
+                    "ToPort": 22,
+                    "IpProtocol": "tcp",
+                    "UserIdGroupPairs": [],
+                    "Ipv6Ranges": []
+                },
+                {
+                    "PrefixListIds": [],
+                    "FromPort": 3389,
+                    "IpRanges": [
+                        {
+                            "CidrIp": "10.1.2.3/32"
+                        }
+                    ],
+                    "ToPort": 3389,
+                    "IpProtocol": "tcp",
+                    "UserIdGroupPairs": [],
+                    "Ipv6Ranges": []
+                }
+            ],
+            "GroupName": "test-group",
+            "VpcId": "vpc-aaaaaaaa",
+            "OwnerId": "123456789012",
+            "GroupId": "sg-cccccccc"
+        }
+    ]
+}


### PR DESCRIPTION
This will (hopefully) add support for EC2-Classic