### PR TITLE
Properly handle launch notifs from attachments

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -41,7 +41,7 @@ def handler(event, context):
         for record in event['Records']:
             if 'Sns' in record and 'Message' in record['Sns']:
                 (init_state, msg) = stepfns.init_machine_state(json.loads(record['Sns']['Message']))
-                if init_state['autoscaling_group']:
+                if init_state.get('autoscaling_group'):
                     logger.debug('Starting execution of {0} with name {1}'.format(state_machine_arn, init_state['ondemand_instance_id']))
                     logger.debug('Input: {}'.format(json.dumps(init_state, indent=2, default=util.json_dumps_converter)))
                     # NOTE: execution ARN is used for locks. if name changes, update lock acquisition & release

--- a/spoptimize/stepfns.py
+++ b/spoptimize/stepfns.py
@@ -45,11 +45,16 @@ def init_machine_state(sns_message):
         return ({}, 'Unable to extract AutoScalingGroupName from SNS message')
     if not sns_message.get('Details'):
         return ({}, 'Unable to extract Details from SNS message')
+    if not sns_message.get('Description'):
+        return ({}, 'Unable to extract Description from SNS message')
     instance_id = sns_message.get('EC2InstanceId')
     group_name = sns_message.get('AutoScalingGroupName')
     subnet_details = sns_message.get('Details', {})
+    desc = sns_message.get('Description')
     if 'Availability Zone' not in subnet_details:
         return ({}, 'Unable to extract Subnet Details from SNS message')
+    if desc[:6] == 'Attach':
+        return ({}, 'Launch notification for attached EC2 instance: {}'.format(desc))
     logger.info('Processing launch notification for {0}: {1} {2}/{3}'.format(
         group_name, instance_id, subnet_details['Availability Zone'], subnet_details.get('Subnet ID')))
     msg = None


### PR DESCRIPTION
A bug bubbled up from #40 - launch notifications from attached instances do not include the `Subnet Id`

Previously the start-state-machine lambda was failing out because of the missing subnet info. After #40, the subnet id was not a require key which then meant spoptimize executed for spoptimized-attached instances as well.