### PR TITLE
Prepare for v1.3.0-pre1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # ChangeLog
 
+## v1.3.0-pre1
+* #[47](https://github.com/vrivellino/spoptimize/pull/47): Fix coveralls badge URL
+* #[46](https://github.com/vrivellino/spoptimize/pull/46): Quick Launch button / nested stack
+* #[44](https://github.com/vrivellino/spoptimize/pull/44): Increased test coverage [Follow-up to #41]
+* #[43](https://github.com/vrivellino/spoptimize/pull/43): Properly handle launch notifications from attached
+    instances. (Fix for bug introduced in #40.)
+* #[41](https://github.com/vrivellino/spoptimize/pull/41): Improved test coverage
+* #[40](https://github.com/vrivellino/spoptimize/pull/40): Allow for missing SubnetId [Follow-up to #39]
+* #[39](https://github.com/vrivellino/spoptimize/pull/39): Support security-group names in launch-config for
+  EC2-Classic support
+* #[38](https://github.com/vrivellino/spoptimize/pull/38): Use auto-scaling instance protection for min OD via
+  `spoptimize:min_protected_instances` tag [Implements #23]
+* New IAM privs: `autoscaling:SetInstanceProtection`, `ec2:DescribeSecurityGroups`
+
 ## v1.2.1
 * #[37](https://github.com/vrivellino/spoptimize/pull/37): Deploy.sh fix
 

--- a/scripts/prepare-for-release.py
+++ b/scripts/prepare-for-release.py
@@ -35,6 +35,10 @@ def gh_pull_request(pr_num):
     return change_log_entry
 
 
+def produce_iam_diff(cur_version_str):
+    return subprocess.check_output(['git', 'diff', '{}...HEAD'.format(cur_version_str.split('-')[0]), 'iam-global.yml'])
+
+
 def update_changelog(lines, cur_version_str, new_version_str):
     with open(os.path.join(here, '..', 'CHANGELOG.md')) as f:
         with open(os.path.join(here, '..', 'CHANGELOG-new.md'), 'w') as w:
@@ -44,7 +48,9 @@ def update_changelog(lines, cur_version_str, new_version_str):
                     w.write('## {}\n'.format(new_version_str))
                     for line_new in lines:
                         w.write(line_new)
-                    w.write('\n')
+                    w.write('\n* New IAM privs:\n```diff\n')
+                    w.write(produce_iam_diff(cur_version_str))
+                    w.write('```\n\n')
                 w.write(line)
 
 


### PR DESCRIPTION
* #47: Fix coveralls badge URL
* #46: Quick Launch button / nested stack
* #44: Increased test coverage [Follow-up to #41]
* #43: Properly handle launch notifications from attached instances. (Fix for bug introduced in #40.)
* #41: Improved test coverage
* #40: Allow for missing SubnetId [Follow-up to #39]
* #39: Support security-group names in launch config for EC2-Classic support
* #38: Use auto-scaling instance protection for min OD via `spoptimize:min_protected_instances` tag [Implements #23]
* New IAM privs: `autoscaling:SetInstanceProtection`, `ec2:DescribeSecurityGroups`